### PR TITLE
configにmax_body_sizeを追加

### DIFF
--- a/include/config/Config.hpp
+++ b/include/config/Config.hpp
@@ -60,6 +60,7 @@ private:
 	ErrorPageMap		error_pages_;
 	DirectiveMap		others_;
 	LocationConfigMap	location_;
+	std::size_t			max_body_size_;
 	Config();//=delete
 
 	// setter
@@ -67,7 +68,7 @@ private:
 	void	setServerName(std::string name);
 	void	setPort(size_t port);
 	void	setRoot(std::string root);
-	void	setMaxBodySize(std::string size);
+	void	setMaxBodySize(size_t size);
 	void	setErrorPage(HttpCode::StatusCode code, std::string page);
 	void	setLocation(Parser& parse, LocationConfig& location, std::string location_path);
 	void	setIndex(std::string index, LocationConfig& location);
@@ -101,6 +102,7 @@ public:
 
 	// getter for attributes (ex location)
 	std::size_t		getPort(void) const;
+	std::size_t		getMaxBodySize(void) const;
 	std::string		getServerName(void) const;
 	std::string		getRoot(std::string const &path = "") const;
 	ErrorPageMap	getErrorPageMap(void) const;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -175,7 +175,12 @@ Config::LocationConfig	Config::getConfigLocation(std::string const &path) const
 	// return (loc);
 }
 
-config::Config::Config(Parser& parse) : port_(80)
+size_t	Config::getMaxBodySize() const
+{
+	return (max_body_size_);
+}
+
+config::Config::Config(Parser& parse) : port_(80), max_body_size_(10000)
 {
 	Config::setConfig(parse);
 }
@@ -229,9 +234,9 @@ void	config::Config::setRoot(std::string root)
 	root_ = root;
 }
 
-void	config::Config::setMaxBodySize(std::string size)
+void	config::Config::setMaxBodySize(size_t size)
 {
-	others_.addValue(MAX_BODY_SIZE, size);
+	max_body_size_ = size;
 }
 
 void	config::Config::setErrorPage(HttpCode::StatusCode code, std::string page)
@@ -283,8 +288,10 @@ bool	config::Config::isMaxBodySize(Parser& parse)
     parse.consume_token();
 	if (!isnums(parse.get_token()))
 		return false;
-	std::string size;
-    size = parse.consume_token();
+    std::stringstream ss;
+	size_t size;
+    ss << parse.consume_token();
+    ss >> size;
 	setMaxBodySize(size);
     if (parse.consume_token() != ";")
         throw ConfigErrorException(parse.get_new_lile_num(), "unexpected \";\":");


### PR DESCRIPTION
## やったこと
size_tでmax_body_sizeを定義
デフォルトで10000持つようにした。
configファイルで1Mのように文字が入っているのは非対応