### PR TITLE
getMaxBodySizeがうまくできない問題を修正

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -80,6 +80,7 @@ Config::Config(Config const &rhs)
 ,error_pages_(rhs.error_pages_)
 ,others_(rhs.others_)
 ,location_(rhs.location_)
+,max_body_size_(rhs.max_body_size_)
 {
 	return ;
 }
@@ -94,6 +95,7 @@ Config &Config::operator=(Config const &rhs)
 		error_pages_ = rhs.error_pages_;
 		others_ = rhs.others_;
 		location_ = rhs.location_;
+		max_body_size_ = rhs.max_body_size_;
 	}
 	return (*this);
 }
@@ -248,6 +250,8 @@ bool	config::Config::isPort(Parser& parse)
 {
     if (parse.get_token() != "listen")
         return false;
+	if (!isnums(parse.get_token()))
+		return false;
     parse.consume_token();
     std::stringstream ss;
 	size_t port;


### PR DESCRIPTION
## やったこと
getMaxBodySizeがうまく動かなかい原因がconfigをpush_buckしているときに使用している代入演算子がmax_body_sizeに対応していないことだったので、追加して修正した。